### PR TITLE
Update CLI.md

### DIFF
--- a/Installation/CLI.md
+++ b/Installation/CLI.md
@@ -1,7 +1,5 @@
 # Windows
-
-On Windows, the GitHub CLI is available via ![scoop](https://scoop.sh/), ![Chocolatey](https://chocolatey.org/), and as downloadable MSI.
-
+On Windows, the GitHub CLI is available via [Scoop](https://scoop.sh/), [Chocolatey](https://chocolatey.org/), and as downloadable MSI.
 #### scoop
 
 Install:


### PR DESCRIPTION
This is just a simple correction to the Github CLI Windows set up method. The previous edit had links that were not directing well to the Scoop and Chocolatey  methods. Now the links are directing to the appropriate web pages.